### PR TITLE
fix input width issue

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -31,6 +31,7 @@ $padding: 0 19px 0 6px;
     margin: $margin;
     outline: none;
     padding: $padding;
+    width: 100%;
 
     &:focus {
       border: $focus-border;


### PR DESCRIPTION
#fix#

Without this property, the input field will not obey to the consumers frost-text width settings unless applied directly to .frost-text input.