### PR TITLE
Re-submitting @laflower's fix to input width

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -27,6 +27,7 @@ $padding: 0 19px 0 6px;
     border: $border;
     color: $color;
     font-size: $font-size;
+    width: 100%;
     height: $height;
     margin: $margin;
     outline: none;

--- a/testem.json
+++ b/testem.json
@@ -3,10 +3,10 @@
   "test_page": "tests/index.html?hidepassed&coverage",
   "disable_watching": true,
   "launch_in_ci": [
-  "PhantomJS"
+  "FireFox"
   ],
   "launch_in_dev": [
-  "PhantomJS",
+  "FireFox",
   "Chrome"
   ]
 }


### PR DESCRIPTION
#fix# to match input width to the frost-text container width