### PR TITLE
Make PR#22 backwards compatible

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -16,6 +16,7 @@ $padding: 0 19px 0 6px;
 .frost-text {
   display: flex;
   align-items: center;
+  width: 173px;
   &.error {
     > input {
       border: $error-border;

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -16,7 +16,8 @@ $padding: 0 19px 0 6px;
 .frost-text {
   display: flex;
   align-items: center;
-  width: 173px;
+  width: 175px;
+  max-width: 385px;
   &.error {
     > input {
       border: $error-border;


### PR DESCRIPTION
#minor# Set width default to 173px (Default of frost-text before width 100% was applied).